### PR TITLE
Creates Module class and DICOM IOD subclasses

### DIFF
--- a/nii2dcm/__main__.py
+++ b/nii2dcm/__main__.py
@@ -30,7 +30,6 @@ def cli(args=None):
 
     input_file = Path(args.input_file)  # TODO: add check that file is .nii/.nii.gz
     output_dir = Path(args.output_dir)  # TODO: add check that this is directory
-    ref_dicom_file = Path(args.ref_dicom)   # TODO: add check that file is DICOM
 
     if not input_file.exists():
         print(f"Input file '{input_file}' not found")
@@ -40,15 +39,22 @@ def cli(args=None):
         print(f"Output directory '{output_dir}' does not exist")
         raise SystemExit(1)
 
-    if not ref_dicom_file.exists():
-        print(f"Reference DICOM file '{ref_dicom}' not found.")
-        raise SystemExit(1)
+    # Coding of optional file checks below is quite verbose
+    if args.dicom_type is not None:
+        dicom_type = args.dicom_type  # TODO: add check that supplied dicom_type is permitted
+    elif args.dicom_type is None:
+        dicom_type = None
+
+    if args.ref_dicom is not None:
+        ref_dicom_file = Path(args.ref_dicom)   # TODO: add check that file is DICOM
+    elif args.ref_dicom is None:
+        ref_dicom_file = None
 
     # execute nii2dcm
     run_nii2dcm(
         input_file,
         output_dir,
-        args.dicom_type,
+        dicom_type,
         ref_dicom_file
     )
 

--- a/nii2dcm/dcm.py
+++ b/nii2dcm/dcm.py
@@ -12,23 +12,21 @@ import pydicom as pyd
 from pydicom.dataset import FileDataset, FileMetaDataset
 
 from nii2dcm.utils import dcm_dictionary_update
-from nii2dcm.modules import (
-    patient,
-    general_study,
-    patient_study,
-    general_series,
-    frame_of_reference,
-    general_equipment,
-    general_acquisition,
-    general_image,
-    general_reference,
-    image_plane,
-    image_pixel,
-    mr_image,
-    voi_lut,
-    sop_common,
-    common_instance_reference,
-)
+from nii2dcm.modules.patient import Patient
+from nii2dcm.modules.general_study import GeneralStudy
+from nii2dcm.modules.patient_study import PatientStudy
+from nii2dcm.modules.general_series import GeneralSeries
+from nii2dcm.modules.frame_of_reference import FrameOfReference
+from nii2dcm.modules.general_equipment import GeneralEquipment
+from nii2dcm.modules.general_acquisition import GeneralAcquisition
+from nii2dcm.modules.general_image import GeneralImage
+from nii2dcm.modules.general_reference import GeneralReference
+from nii2dcm.modules.image_plane import ImagePlane
+from nii2dcm.modules.image_pixel import ImagePixel
+from nii2dcm.modules.mr_image import MRImage
+from nii2dcm.modules.sop_common import SOPCommon
+from nii2dcm.modules.common_instance_reference import CommonInstanceReference
+from nii2dcm.modules.voi_lut import VOILUT
 
 nii2dcm_temp_filename = 'nii2dcm_tempfile.dcm'
 
@@ -64,26 +62,8 @@ class Dicom:
 
         """
         Initialise Composite IOD by adding Modules to Dicom object
-        
-        Common Modules below taken by comparing A.3.3 (CT) and A.4.3 (MRI) CIODs to determine shared Modules. Other 
-        modalities assumed to have similar composition. Modules unique to a specific imaging modality are added within 
-        the respective subclass. e.g. MR Image Module is added within the nii2dcm DicomMRI class
         """
-        patient.add_module(self)
-        general_study.add_module(self)
-        patient_study.add_module(self)
-        general_series.add_module(self)
-        frame_of_reference.add_module(self)
-        general_equipment.add_module(self)
-        general_acquisition.add_module(self)
-
-        general_image.add_module(self)
-        general_reference.add_module(self)
-        image_plane.add_module(self)
-        image_pixel.add_module(self)
-        voi_lut.add_module(self)
-        sop_common.add_module(self)
-        common_instance_reference.add_module(self)
+        self.add_base_modules()
 
         """
         Set Dicom Date/Time
@@ -132,6 +112,49 @@ class Dicom:
 
         self.init_study_tags()
         self.init_series_tags()
+
+    def add_module(self, module_obj):
+        """
+        Update Dicom object with DICOM elements from Module object
+        :param module_obj: Module object
+        :return: updated Dicom object
+        """
+
+        # TODO add logger statements
+        # logging(f'Updating Dicom object with DICOM elements from Module: {module.name}.')
+
+        for elem in module_obj.ds:
+            # logging('Original Element:', self.ds[elem.keyword])
+            # logging('Module Element:', elem)
+            self.ds.add(elem)
+            # logging('New Tag:', self.ds[elem.keyword])
+
+    def add_base_modules(self):
+        """
+        Initialise Composite IOD by adding Modules to Dicom object
+
+        Common Modules below taken by comparing A.3.3 (CT) and A.4.3 (MRI) CIODs to determine shared Modules. Other
+        modalities assumed to have similar composition. Modules unique to a specific imaging modality are added within
+        the respective subclass. e.g. MR Image Module is added within the nii2dcm DicomMRI class
+        """
+        self.add_module(Patient())
+        self.add_module(GeneralStudy())
+        self.add_module(PatientStudy())
+        self.add_module(GeneralSeries())
+        self.add_module(FrameOfReference())
+        self.add_module(GeneralEquipment())
+
+        # Image IE
+        # TODO potentially transfer these Modules to Dicom subclasses because they are image-based,
+        #  whereas Modules above are generic, non-image Modules, e.g. patient details, file information etc.
+        self.add_module(GeneralImage())
+        self.add_module(GeneralAcquisition())
+        self.add_module(GeneralReference())
+        self.add_module(ImagePlane())
+        self.add_module(ImagePixel())
+        self.add_module(SOPCommon())
+        self.add_module(CommonInstanceReference())
+        self.add_module(VOILUT())
 
     def get_file_meta(self):
         return self.file_meta
@@ -199,7 +222,7 @@ class DicomMRI(Dicom):
         """
         Initialise subclass CIOD Modules
         """
-        mr_image.add_module(self)
+        self.add_module(MRImage())
 
         """
         DICOM Attributes to transfer from DICOM supplied using --ref_dicom CLI option

--- a/nii2dcm/module.py
+++ b/nii2dcm/module.py
@@ -1,0 +1,18 @@
+"""
+module.py
+"""
+
+from pydicom.dataset import Dataset
+
+
+class Module:
+
+    def __init__(self):
+        """
+        Creates generic Module object with empty Pydicom Dataset object
+
+        nb: below somewhat superfluous – building out for future
+        """
+        self.module_type = 'GenericModule'
+
+        self.ds = Dataset()

--- a/nii2dcm/modules/common_instance_reference.py
+++ b/nii2dcm/modules/common_instance_reference.py
@@ -5,15 +5,17 @@ C.12.2
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.12.2.html
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    # ReferencedSeriesSequence
-    # omit for now, but can be important for references Instances/Series with other Series
-    # dcm.ds.ReferencedSeriesSequence = ''
-    pass
+class CommonInstanceReference(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'CommonInstanceReference'
+
+        # ReferencedSeriesSequence
+        # omit for now, but can be important for references Instances/Series with other Series
+        # self.ds.ReferencedSeriesSequence = ''
+        pass

--- a/nii2dcm/modules/frame_of_reference.py
+++ b/nii2dcm/modules/frame_of_reference.py
@@ -5,13 +5,15 @@ C.7.4.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.4.html#sect_C.7.4.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.FrameOfReferenceUID = ''
-    # dcm.ds.PositionReferenceIndicator = ''  # TODO add robustly
+class FrameOfReference(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'FrameOfReference'
+
+        self.ds.FrameOfReferenceUID = ''
+        # self.ds.PositionReferenceIndicator = ''  # TODO add robustly

--- a/nii2dcm/modules/general_acquisition.py
+++ b/nii2dcm/modules/general_acquisition.py
@@ -5,16 +5,18 @@ C.7.10.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.10.html#sect_C.7.10.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    # TODO generate Acquisition values here - perhaps with date/time subfunction - or perform within Dicom class
-    #  (as currently doing)?
-    dcm.ds.AcquisitionNumber = ''
-    dcm.ds.AcquisitionDate = ''
-    dcm.ds.AcquisitionTime = ''
+class GeneralAcquisition(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'GeneralAcquisition'
+
+        # TODO generate Acquisition values here - perhaps with date/time subfunction - or perform within Dicom class
+        #  (as currently doing)?
+        self.ds.AcquisitionNumber = ''
+        self.ds.AcquisitionDate = ''
+        self.ds.AcquisitionTime = ''

--- a/nii2dcm/modules/general_equipment.py
+++ b/nii2dcm/modules/general_equipment.py
@@ -5,15 +5,17 @@ C.7.5.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.5.html#sect_C.7.5.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.Manufacturer = ''
-    dcm.ds.InstitutionName = 'INSTITUTION_NAME_UNDEFINED'
-    dcm.ds.ManufacturerModelName = ""
-    dcm.ds.SoftwareVersions = ''
+class GeneralEquipment(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'GeneralEquipment'
+
+        self.ds.Manufacturer = ''
+        self.ds.InstitutionName = 'INSTITUTION_NAME_UNDEFINED'
+        self.ds.ManufacturerModelName = ""
+        self.ds.SoftwareVersions = ''

--- a/nii2dcm/modules/general_image.py
+++ b/nii2dcm/modules/general_image.py
@@ -5,23 +5,25 @@ C.7.6.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.html#sect_C.7.6.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.InstanceNumber = ''
-    dcm.ds.PatientOrientation = ''
-    dcm.ds.ContentDate = ''
-    dcm.ds.ContentTime = ''
-    dcm.ds.ImageType = ['SECONDARY', 'DERIVED']
+class GeneralImage(Module):
 
-    # LossyImageCompression
-    # Enumerated values either:
-    # 00 = no lossy compression
-    # 01 = lossy compression
-    dcm.ds.LossyImageCompression = '00'
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'GeneralImage'
+
+        self.ds.InstanceNumber = ''
+        self.ds.PatientOrientation = ''
+        self.ds.ContentDate = ''
+        self.ds.ContentTime = ''
+        self.ds.ImageType = ['SECONDARY', 'DERIVED']
+
+        # LossyImageCompression
+        # Enumerated values either:
+        # 00 = no lossy compression
+        # 01 = lossy compression
+        self.ds.LossyImageCompression = '00'
 

--- a/nii2dcm/modules/general_reference.py
+++ b/nii2dcm/modules/general_reference.py
@@ -5,13 +5,16 @@ C.12.4
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.12.4.html
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    pass
+class GeneralReference(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'GeneralReference'
+
+        # TODO update placeholder class
+        pass
 

--- a/nii2dcm/modules/general_series.py
+++ b/nii2dcm/modules/general_series.py
@@ -5,28 +5,30 @@ C.7.3.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.3.html#sect_C.7.3.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.Modality = ''  # initiated, should be defined by Dicom subclass
-    dcm.ds.SeriesInstanceUID = ''  # initiated, but value set in dcm.Dicom.init_series_tags()
-    dcm.ds.SeriesNumber = ''  # initiated, but value set in dcm.Dicom.init_series_tags()
-    dcm.ds.ProtocolName = "nii2dcm_DICOM"
+class GeneralSeries(Module):
 
-    # PatientPosition
-    # From NEMA: required for images where Patient Orientation Code Sequence (0054,0410) is not present and whose
-    # SOP Class is one of the following:
-    # CT ("1.2.840.10008.5.1.4.1.1.2") or
-    # MR ("1.2.840.10008.5.1.4.1.1.4") or
-    # Enhanced CT ("1.2.840.10008.5.1.4.1.1.2.1") or
-    # Enhanced MR Image ("1.2.840.10008.5.1.4.1.1.4.1") or
-    # Enhanced Color MR Image ("1.2.840.10008.5.1.4.1.1.4.3") or
-    # MR Spectroscopy ("1.2.840.10008.5.1.4.1.1.4.2")
-    dcm.ds.PatientPosition = ''
+    def __init__(self):
+        super().__init__()
 
-    dcm.ds.AccessionNumber = "ABCXYZ"
+        self.module_type = 'GeneralSeries'
+
+        self.ds.Modality = ''  # initiated, should be defined by Dicom subclass
+        self.ds.SeriesInstanceUID = ''  # initiated, but value set by Dicom.init_series_tags()
+        self.ds.SeriesNumber = ''  # initiated, but value set by Dicom.init_series_tags()
+        self.ds.ProtocolName = "nii2dcm_DICOM"
+
+        # PatientPosition
+        # From NEMA: required for images where Patient Orientation Code Sequence (0054,0410) is not present and whose
+        # SOP Class is one of the following:
+        # CT ("1.2.840.10008.5.1.4.1.1.2") or
+        # MR ("1.2.840.10008.5.1.4.1.1.4") or
+        # Enhanced CT ("1.2.840.10008.5.1.4.1.1.2.1") or
+        # Enhanced MR Image ("1.2.840.10008.5.1.4.1.1.4.1") or
+        # Enhanced Color MR Image ("1.2.840.10008.5.1.4.1.1.4.3") or
+        # MR Spectroscopy ("1.2.840.10008.5.1.4.1.1.4.2")
+        self.ds.PatientPosition = ''
+
+        self.ds.AccessionNumber = "ABCXYZ"

--- a/nii2dcm/modules/general_study.py
+++ b/nii2dcm/modules/general_study.py
@@ -6,15 +6,18 @@ https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.2.html
 """
 
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
+from nii2dcm.module import Module
 
-    dcm.ds.StudyInstanceUID = ''  # attribute initialised but value initialised in Dicom class
-    dcm.ds.StudyDescription = ''
-    dcm.ds.ReferringPhysicianName = ''
+
+class GeneralStudy(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'GeneralStudy'
+
+        self.ds.StudyInstanceUID = ''  # attribute initialised but value initialised in Dicom class
+        self.ds.StudyDescription = ''
+        self.ds.ReferringPhysicianName = ''
 
 

--- a/nii2dcm/modules/image_pixel.py
+++ b/nii2dcm/modules/image_pixel.py
@@ -11,26 +11,32 @@ https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.3.3.
 """
 
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
+from nii2dcm.module import Module
 
-    dcm.ds.Rows = ''
-    dcm.ds.Columns = ''
-    dcm.ds.BitsAllocated = ''
-    dcm.ds.BitsStored = ''
-    dcm.ds.HighBit = ''
 
-    # PixelRepresentation
-    # Enumerated values either: unsigned integer or two's complement
-    # Setting = 0, as observed in real DICOM
-    dcm.ds.PixelRepresentation = 0
+class ImagePixel(Module):
 
-    dcm.ds.SmallestImagePixelValue = ''
-    dcm.ds.LargestImagePixelValue = ''
+    def __init__(self):
+        super().__init__()
 
-    # PixelData written in dcm_writer via Pydicom
-    dcm.ds.PixelData = ''
+        self.module_type = 'ImagePixel'
+
+        self.ds.Rows = ''
+        self.ds.Columns = ''
+
+        # BitsAllocated, BitsStored, HighBit
+        # Setting default = 1 for purposes of basic DICOM creation. Should be overwritten by Dicom subclass.
+        self.ds.BitsAllocated = 1
+        self.ds.BitsStored = ''
+        self.ds.HighBit = ''
+    
+        # PixelRepresentation
+        # Enumerated values either: unsigned integer or two's complement
+        # Setting = 0, as observed in real DICOM
+        self.ds.PixelRepresentation = 0
+    
+        self.ds.SmallestImagePixelValue = ''
+        self.ds.LargestImagePixelValue = ''
+    
+        # PixelData written in dcm_writer via Pydicom
+        self.ds.PixelData = ''

--- a/nii2dcm/modules/image_plane.py
+++ b/nii2dcm/modules/image_plane.py
@@ -5,17 +5,19 @@ C.7.6.2
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.2.html
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.PixelSpacing = ''
-    dcm.ds.ImageOrientationPatient = ''  # TODO set here or in Dicom class?
-    dcm.ds.ImagePositionPatient = ''  # TODO set here or in Dicom class?
-    dcm.ds.SliceThickness = ''
-    dcm.ds.SpacingBetweenSlices = ''
-    dcm.ds.SliceLocation = ''  # maths: https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.2.html#sect_C.7.6.2.1.2
+class ImagePlane(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'ImagePlane'
+
+        self.ds.PixelSpacing = ''
+        self.ds.ImageOrientationPatient = ''  # TODO set here or in Dicom class?
+        self.ds.ImagePositionPatient = ''  # TODO set here or in Dicom class?
+        self.ds.SliceThickness = ''
+        self.ds.SpacingBetweenSlices = ''
+        self.ds.SliceLocation = ''  # maths: https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.2.html#sect_C.7.6.2.1.2

--- a/nii2dcm/modules/mr_image.py
+++ b/nii2dcm/modules/mr_image.py
@@ -9,90 +9,93 @@ an MRI scanner.
 """
 
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
+from nii2dcm.module import Module
 
-    # ImageType
-    # NEMA defines MR-specific ImageType terms here:
-    # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.8.3.html#sect_C.8.3.1.1.1
-    # For now, will inherit
-    dcm.ds.ImageType = dcm.ds.ImageType
 
-    dcm.ds.SamplesPerPixel = 1
+class MRImage(Module):
 
-    # PhotometricInterpretation
-    # TODO: decide MONOCHROME1 or MONOCHROME2 as default
-    # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.3.html#sect_C.7.6.3.1.2
-    dcm.ds.PhotometricInterpretation = 'MONOCHROME2'
+    def __init__(self):
+        super().__init__()
 
-    # PresentationLUTShape
-    # depends on PhotometricInterpretation: https://dicom.innolitics.com/ciods/mr-image/general-image/20500020
-    if dcm.ds.PhotometricInterpretation == 'MONOCHROME2':
-        dcm.ds.PresentationLUTShape = 'IDENTITY'
-    elif dcm.ds.PhotometricInterpretation == 'MONOCHROME1':
-        dcm.ds.PresentationLUTShape = 'INVERSE'
+        self.module_type = 'MRImage'
 
-    # Bits Allocated
-    # defined to equal 16 for MR Image Module
-    # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.8.3.html#sect_C.8.3.1.1.4
-    dcm.ds.BitsAllocated = 16
-    dcm.ds.BitsStored = 12
-    dcm.ds.HighBit = dcm.ds.BitsStored - 1
-
-    dcm.ds.ScanningSequence = 'RM'  # :missing:, 'RM' = Research Mode
-    dcm.ds.SequenceVariant = ''  # :missing:
-    dcm.ds.ScanOptions = ''  # :missing:
-    dcm.ds.MRAcquisitionType = ''  # 2D or 3D
-    dcm.ds.RepetitionTime = ''
-    dcm.ds.EchoTime = ''
-    dcm.ds.EchoTrainLength = ''
-    dcm.ds.InversionTime = ''
-    dcm.ds.TriggerTime = ''
-    dcm.ds.SequenceName = ''
-    dcm.ds.AngioFlag = ''  # :missing:
-    dcm.ds.NumberOfAverages = ''
-    dcm.ds.ImagingFrequency = ''
-    dcm.ds.ImagedNucleus = ''
-    dcm.ds.EchoNumbers = ''
-    dcm.ds.MagneticFieldStrength = ''
-    dcm.ds.NumberOfPhaseEncodingSteps = ''  # :missing:
-    dcm.ds.PercentSampling = ''  # TODO set?
-    dcm.ds.PercentPhaseFieldOfView = ''  # TODO set?
-    dcm.ds.PixelBandwidth = ''
-    dcm.ds.NominalInterval = ''  # :missing:
-    dcm.ds.BeatRejectionFlag = ''  # :missing:
-    dcm.ds.LowRRValue = ''  # :missing:
-    dcm.ds.HighRRValue = ''  # :missing:
-    dcm.ds.IntervalsAcquired = ''  # :missing:
-    dcm.ds.IntervalsRejected = ''  # :missing:
-    dcm.ds.PVCRejection = ''  # :missing:
-    dcm.ds.SkipBeats = ''  # :missing:
-    dcm.ds.HeartRate = ''
-    dcm.ds.CardiacNumberOfImages = ''
-    dcm.ds.TriggerWindow = ''
-    dcm.ds.ReconstructionDiameter = ''  # :missing:
-    dcm.ds.ReceiveCoilName = ''
-    dcm.ds.TransmitCoilName = ''
-    dcm.ds.AcquisitionMatrix = ''  # :missing:
-    dcm.ds.InPlanePhaseEncodingDirection = ''  # ROW or COLUMN
-    dcm.ds.FlipAngle = ''
-    dcm.ds.SAR = ''
-    dcm.ds.VariableFlipAngleFlag = ''  # :missing:
-    dcm.ds.dBdt = ''
-    dcm.ds.TemporalPositionIdentifier = ''  # :missing:
-    dcm.ds.NumberOfTemporalPositions = ''
-    dcm.ds.TemporalResolution = ''  # :missing:
-
-    # Currently omitting, but part of NEMA MR Image module:
-    # NEMA Table 10-7 “General Anatomy Optional Macro Attributes”
-
-    # Currently omitting, but part of NEMA MR Image module:
-    # NEMA Table 10-25 “Optional View and Slice Progression Direction Macro Attributes”
-
-    dcm.ds.IsocenterPosition = ''  # :missing:
-    dcm.ds.B1rms = ''
+        # ImageType
+        # NEMA defines MR-specific ImageType terms here:
+        # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.8.3.html#sect_C.8.3.1.1.1
+        # For now, will omit thereby inheriting parent value
+        # self.ds.ImageType = ''
+    
+        self.ds.SamplesPerPixel = 1
+    
+        # PhotometricInterpretation
+        # TODO: decide MONOCHROME1 or MONOCHROME2 as default
+        # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.6.3.html#sect_C.7.6.3.1.2
+        self.ds.PhotometricInterpretation = 'MONOCHROME2'
+    
+        # PresentationLUTShape
+        # depends on PhotometricInterpretation: https://dicom.innolitics.com/ciods/mr-image/general-image/20500020
+        if self.ds.PhotometricInterpretation == 'MONOCHROME2':
+            self.ds.PresentationLUTShape = 'IDENTITY'
+        elif self.ds.PhotometricInterpretation == 'MONOCHROME1':
+            self.ds.PresentationLUTShape = 'INVERSE'
+    
+        # Bits Allocated
+        # defined to equal 16 for MR Image Module
+        # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.8.3.html#sect_C.8.3.1.1.4
+        self.ds.BitsAllocated = 16
+        self.ds.BitsStored = 12
+        self.ds.HighBit = self.ds.BitsStored - 1
+    
+        self.ds.ScanningSequence = 'RM'  # :missing:, 'RM' = Research Mode
+        self.ds.SequenceVariant = ''  # :missing:
+        self.ds.ScanOptions = ''  # :missing:
+        self.ds.MRAcquisitionType = ''  # 2D or 3D
+        self.ds.RepetitionTime = ''
+        self.ds.EchoTime = ''
+        self.ds.EchoTrainLength = ''
+        self.ds.InversionTime = ''
+        self.ds.TriggerTime = ''
+        self.ds.SequenceName = ''
+        self.ds.AngioFlag = ''  # :missing:
+        self.ds.NumberOfAverages = ''
+        self.ds.ImagingFrequency = ''
+        self.ds.ImagedNucleus = ''
+        self.ds.EchoNumbers = ''
+        self.ds.MagneticFieldStrength = ''
+        self.ds.NumberOfPhaseEncodingSteps = ''  # :missing:
+        self.ds.PercentSampling = ''  # TODO set?
+        self.ds.PercentPhaseFieldOfView = ''  # TODO set?
+        self.ds.PixelBandwidth = ''
+        self.ds.NominalInterval = ''  # :missing:
+        self.ds.BeatRejectionFlag = ''  # :missing:
+        self.ds.LowRRValue = ''  # :missing:
+        self.ds.HighRRValue = ''  # :missing:
+        self.ds.IntervalsAcquired = ''  # :missing:
+        self.ds.IntervalsRejected = ''  # :missing:
+        self.ds.PVCRejection = ''  # :missing:
+        self.ds.SkipBeats = ''  # :missing:
+        self.ds.HeartRate = ''
+        self.ds.CardiacNumberOfImages = ''
+        self.ds.TriggerWindow = ''
+        self.ds.ReconstructionDiameter = ''  # :missing:
+        self.ds.ReceiveCoilName = ''
+        self.ds.TransmitCoilName = ''
+        self.ds.AcquisitionMatrix = ''  # :missing:
+        self.ds.InPlanePhaseEncodingDirection = ''  # ROW or COLUMN
+        self.ds.FlipAngle = ''
+        self.ds.SAR = ''
+        self.ds.VariableFlipAngleFlag = ''  # :missing:
+        self.ds.dBdt = ''
+        self.ds.TemporalPositionIdentifier = ''  # :missing:
+        self.ds.NumberOfTemporalPositions = ''
+        self.ds.TemporalResolution = ''  # :missing:
+    
+        # Currently omitting, but part of NEMA MR Image module:
+        # NEMA Table 10-7 “General Anatomy Optional Macro Attributes”
+    
+        # Currently omitting, but part of NEMA MR Image module:
+        # NEMA Table 10-25 “Optional View and Slice Progression Direction Macro Attributes”
+    
+        self.ds.IsocenterPosition = ''  # :missing:
+        self.ds.B1rms = ''
 

--- a/nii2dcm/modules/patient.py
+++ b/nii2dcm/modules/patient.py
@@ -5,16 +5,17 @@ C.7.1.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.html#sect_C.7.1.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.PatientName = 'Lastname^Firstname'
-    dcm.ds.PatientID = '12345678'
-    dcm.ds.PatientSex = ''
-    dcm.ds.PatientBirthDate = ''
+class Patient(Module):
 
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'PatientModule'
+
+        self.ds.PatientName = 'Lastname^Firstname'
+        self.ds.PatientID = '12345678'
+        self.ds.PatientSex = ''
+        self.ds.PatientBirthDate = ''

--- a/nii2dcm/modules/patient_study.py
+++ b/nii2dcm/modules/patient_study.py
@@ -5,13 +5,15 @@ C.7.2.2
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.7.2.2.html
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.PatientAge = ""
-    dcm.ds.PatientWeight = ""
+class PatientStudy(Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'PatientStudy'
+
+        self.ds.PatientAge = ""
+        self.ds.PatientWeight = ""

--- a/nii2dcm/modules/sop_common.py
+++ b/nii2dcm/modules/sop_common.py
@@ -5,22 +5,24 @@ C.12.1
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    dcm.ds.SOPClassUID = ''  # initiated, should be defined by Dicom subclass
-    dcm.ds.SOPInstanceUID = ''
+class SOPCommon(Module):
 
-    # SpecificCharacterSet
-    # Default set to ISO_IR 100 = Latin alphabet No. 1
-    # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1.1.2
-    dcm.ds.SpecificCharacterSet = 'ISO_IR 100'
-    dcm.ds.InstanceCreationDate = ''
-    dcm.ds.InstanceCreationTime = ''
+    def __init__(self):
+        super().__init__()
 
-    dcm.ds.InstanceCreatorUID = ''
+        self.module_type = 'SOPCommon'
+
+        self.ds.SOPClassUID = ''  # initiated, should be defined by Dicom subclass
+        self.ds.SOPInstanceUID = ''
+    
+        # SpecificCharacterSet
+        # Default set to ISO_IR 100 = Latin alphabet No. 1
+        # https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1.1.2
+        self.ds.SpecificCharacterSet = 'ISO_IR 100'
+        self.ds.InstanceCreationDate = ''
+        self.ds.InstanceCreationTime = ''
+    
+        self.ds.InstanceCreatorUID = ''

--- a/nii2dcm/modules/voi_lut.py
+++ b/nii2dcm/modules/voi_lut.py
@@ -5,18 +5,20 @@ C.11.2
 https://dicom.nema.org/medical/Dicom/current/output/chtml/part03/sect_C.11.2.html
 """
 
+from nii2dcm.module import Module
 
-def add_module(dcm):
-    """
-    Adds Module to Pydicom Dataset object
-    :param dcm: input Pydicom Dataset object
-    :return: updated Pydicom Dataset object
-    """
 
-    # WindowCenter
-    # From NEMA: Required if VOI LUT Sequence (0028,3010) is not present. May be present otherwise.
-    dcm.ds.WindowCenter = ''
+class VOILUT(Module):
 
-    # WindowWidth
-    # Required if Window Center (0028,1050) is present.
-    dcm.ds.WindowWidth = ''
+    def __init__(self):
+        super().__init__()
+
+        self.module_type = 'VOILUT'
+
+        # WindowCenter
+        # From NEMA: Required if VOI LUT Sequence (0028,3010) is not present. May be present otherwise.
+        self.ds.WindowCenter = ''
+    
+        # WindowWidth
+        # Required if Window Center (0028,1050) is present.
+        self.ds.WindowWidth = ''


### PR DESCRIPTION
Creates:
- `Module` class
- Various subclasses in `modules` folder which together create a Composite IOD
- Updates code accordingly

Tested locally
- With no `--dicom_type` option, a DICOM dataset is created
- With `--dicom_type MR` option, a DICOM dataset is created and opens in ITK-Snap but contrast is weird. Tested with SVR-output.nii.gz and generic CT converted to Nifti. Need to resolve this.
- With `--dicom_type SVR` option, a DICOM dataset is created and opens in ITK-Snap
