### PR TITLE
Updates publish to TestPyPI GitHub Action / Adds publish to PyPI GitHub Action

### DIFF
--- a/.github/workflows/build_and_test_cli.yml
+++ b/.github/workflows/build_and_test_cli.yml
@@ -17,12 +17,10 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ '3.9' ]
 
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -32,6 +30,7 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools wheel
         pip install flake8 pytest pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,99 @@
+# Publish to PyPI
+#
+# This workflow publishes nii2dcm on PyPI. The workflow triggers
+# on release. The PyPI release is labelled according to the git tag
+# specified in the GitHub Release user interface. For instance,
+# if the TestPyPI release is v0.1.2.post16, then the GitHub Release
+# tag should be entered as v0.1.3, which will propagate to PyPI.
+# Subsequent developer commits will become v0.1.3.post1, v0.1.3.post2,
+# and so on.
+#
+# This workflow will upload a Python Package using Twine when a release is created. For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+#
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish package to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  testpypi-publish:
+
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nii2dcm
+    permissions:
+      contents: read
+      actions: write
+      id-token: write  # IMPORTANT: this permission is mandatory for PyPI trusted publishing
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+        pip install -r requirements.txt
+
+    - name: Build package
+      run: pip install .
+
+    - name: Display version via dunamai
+      run: |
+        echo "version via dunamai:"
+        dunamai from any
+
+    - name: Display version via nii2dcm CLI
+      run: |
+        echo "version via nii2dcm CLI:"
+        nii2dcm -v
+
+    - name: Create dist/
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true
+
+    - name: Wait to allow PyPI to update
+      uses: GuillaumeFalourd/wait-sleep-action@v1
+      with:
+        time: '150'  # seconds
+
+    - name: Install latest PyPI version in fresh venv
+      run: |
+        NII2DCM_VERSION=`echo "$(nii2dcm -v)"`
+        echo $NII2DCM_VERSION
+        python -m venv nii2dcm-temp
+        source nii2dcm-temp/bin/activate
+        pip install --upgrade pip
+        pip install setuptools wheel
+        pip install nii2dcm==$NII2DCM_VERSION
+        nii2dcm -h
+        echo "nii2dcm version:"
+        nii2dcm -v

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - main
-      - 24-gha-pypi
 
 permissions:
   contents: read

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -54,16 +54,16 @@ jobs:
         pip install -r requirements.txt
 
     - name: Build package
-      run: python setup.py install  # TODO: fix pip install -e .
+      run: pip install .
 
     - name: Display version via dunamai
       run: |
-        echo "dunamai version:"
+        echo "version via dunamai:"
         dunamai from any
 
     - name: Display version via nii2dcm CLI
       run: |
-        echo "nii2dcm version:"
+        echo "version via nii2dcm CLI:"
         nii2dcm -v
 
     - name: Create dist/

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -62,7 +62,6 @@ jobs:
         dunamai from any
 
     - name: Display version via nii2dcm CLI
-      id: nii2dcm-version
       run: |
 #        pip install -e .
         echo "nii2dcm version:"

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -63,7 +63,6 @@ jobs:
 
     - name: Display version via nii2dcm CLI
       run: |
-#        pip install -e .
         echo "nii2dcm version:"
         nii2dcm -v
 

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -1,7 +1,9 @@
 # Publish to TestPyPI
 #
-# This workflow publishes nii2dcm on TestPyPI prior to production release onto PyPI. The workflow is intended to catch
-# any issues arising during the release procedure to prevent unnecessary versioning issues on PyPI
+# This workflow publishes nii2dcm on TestPyPI prior to
+# production release onto PyPI. The workflow is intended to
+# catch any issues arising during the release procedure to
+# prevent unnecessary versioning issues on PyPI.
 #
 # This workflow will upload a Python Package using Twine when a release is created. For more information see:
 # https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
@@ -14,20 +16,25 @@
 name: Publish package to TestPyPI
 
 on:
-  pull_request
+  push:
+    branches:
+      - main
+      - 24-gha-pypi
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   testpypi-publish:
 
-    name: Publish release to TestPyPI
     runs-on: ubuntu-latest
     environment:
       name: testpypi
       url: https://test.pypi.org/p/nii2dcm
     permissions:
+      contents: read
+      actions: write
       id-token: write  # IMPORTANT: this permission is mandatory for PyPI trusted publishing
 
     steps:
@@ -43,17 +50,36 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install setuptools wheel
+        pip install -r requirements.txt
 
     - name: Build package
-      run: python -m build --sdist --wheel --outdir dist/
+      run: python setup.py install
 
-    - name: Display nii2dcm version
+    - name: Display version via dunamai
+      run: |
+        echo "dunamai version:"
+        dunamai from any
+
+    - name: Display version via nii2dcm CLI
       id: nii2dcm-version
       run: |
-        pip install -e .
+#        pip install -e .
         echo "nii2dcm version:"
         nii2dcm -v
+
+    - name: Create dist/
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+
+    - name: Remove .egg
+      run: |
+        echo "dist/ before:"
+        ls dist/
+        [ -f "./dist/*.egg" ] && "Deleting .egg file as not permitted on PyPI" || rm ./dist/*.egg
+        echo "dist/ after:"
+        ls dist/
 
     - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -54,7 +54,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: Build package
-      run: python setup.py install
+      run: python setup.py install  # TODO: fix pip install -e .
 
     - name: Display version via dunamai
       run: |

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -71,14 +71,6 @@ jobs:
         python setup.py sdist bdist_wheel
         twine check dist/*
 
-    - name: Remove .egg
-      run: |
-        echo "dist/ before:"
-        ls dist/
-        [ -f "./dist/*.egg" ] && "Deleting .egg file as not permitted on PyPI" || rm ./dist/*.egg
-        echo "dist/ after:"
-        ls dist/
-
     - name: Publish package to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,5 @@ _im*
 *.nii
 *.nii.gz
 
-# Omit _version.py as required by setuptools_scm
-nii2dcm/_version.py
-
 # Permit Test Data
 !tests/data/DicomMRISVR/t2-svr-atlas-35wk.nii.gz

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ nii2dcm SVR-output.nii.gz path/to/output/dir/ -d SVR
 <!-- ROADMAP -->
 ## Roadmap
 
-This project is in its infancy! Expect :bug::ant::beetle:
+This project is in its infancy! Expect bugs :bug::ant::beetle:
 
 There are many things I would like to test and implement. 
 [Raise an Issue](https://github.com/tomaroberts/nii2dcm/issues) if you have ideas or suggestions.

--- a/nii2dcm/_version.py
+++ b/nii2dcm/_version.py
@@ -1,0 +1,2 @@
+from dunamai import Version, Style
+__version__ = Version.from_git().serialize(metadata=False, style=Style.SemVer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
-build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,3 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=64.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "nii2dcm"
-dynamic = ["version"]
-
-[tool.setuptools_scm]
-local_scheme = "no-local-version"  # required for PyPI and TestPyPI
-write_to = "nii2dcm/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib==3.6.2
 nibabel==5.0.0
 pydicom==2.3.0
 twine==4.0.2
+dunamai==1.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nii2dcm
-version = attr: nii2dcm._version.__version__
+version = attr: nii2dcm.__init__.__version__
 description= nii2dcm: NIfTI to DICOM creation with Python
 url = https://github.com/tomaroberts/nii2dcm
 author = Tom Roberts
@@ -17,6 +17,7 @@ install_requires =
     nibabel==5.0.0
     pydicom==2.3.0
     twine==4.0.2
+    dunamai==1.18.0
 include_package_data=True
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+from dunamai import Version, Style
+
+setup(
+    name="nii2dcm",
+    version=Version.from_git().serialize(metadata=False, style=Style.SemVer),
+)


### PR DESCRIPTION
Resolves #24 and improves upon implementation of #23 

- Implements [dunamai](https://github.com/mtkennerly/dunamai)
- Version number updated with each commit using X.Y.Z.postN format (SemVer, so compatible with PyPI)
- Publication on TestPyPI with every push on `main`
   - Verifies that python package will build and runs basic nii2dcm CLI check
- Publication on PyPI with every Release
   - Version number set by Release tag in format `vX.Y.Z`